### PR TITLE
Add 3 (Discord Nitro Basic) in NitroTypes

### DIFF
--- a/Accord/Objects/DiscordTypes/User.swift
+++ b/Accord/Objects/DiscordTypes/User.swift
@@ -80,4 +80,5 @@ enum NitroTypes: Int, Codable {
     case none = 0
     case classic = 1
     case nitro = 2
+    case basic = 3
 }


### PR DESCRIPTION
This fixes Nitroless erroring and causing the UI to be stuck at the "connecting" view. Resolves the `dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "d", intValue: nil), CodingKeys(stringValue: "user", intValue: nil), CodingKeys(stringValue: "premium_type", intValue: nil)], debugDescription: "Cannot initialize NitroTypes from invalid Int value 3", underlyingError: nil))` error.