### PR TITLE
fix: focused objects in the loading screen

### DIFF
--- a/Accord/App/AccordApp.swift
+++ b/Accord/App/AccordApp.swift
@@ -118,7 +118,6 @@ struct AccordApp: App {
                         loaded = false
                     }
                     .preferredColorScheme(darkMode ? .dark : nil)
-                    .focusable()
                     .onAppear {
                         // Globals.loadVersion()
                         // DispatchQueue(label: "socket").async {


### PR DESCRIPTION
Removes .focused() from the ContentView in AccordApp.swift